### PR TITLE
Fix to build composer project with PHP > 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -129,7 +129,7 @@
                 "reference":"main"
               }
             }
-        },                
+        },
         {
             "type": "package",
             "package": {
@@ -344,7 +344,7 @@
         "drupal/fits": "^1.1@alpha",
         "drupal/media_thumbnails": "^1.0@alpha",
         "drupal/media_thumbnails_pdf": "^1.0@alpha",
-        "drupal/media_thumbnails_video": "^1.0@alpha",
+        "drupal/media_thumbnails_video": "^1.0@dev",
         "drupal/csv_importer": "^1.11",
         "drupal/tombstones": "^1.0@alpha",
         "react/child-process": "^0.6.4",


### PR DESCRIPTION
The Media Thumbnails Video module's version required in this project's composer will not build on PHP version 8.0 or later.

The dev branch updates its requirements so it now works.

Drupal.org issue: https://www.drupal.org/project/media_thumbnails_video/issues/3274875