### PR TITLE
Patch to fix white screen caused by Field Conditions module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -470,6 +470,9 @@
             "drupal/core": "-p2"
         },
         "patches": {
+            "drupal/fico": {
+                "Call to undefined method Drupal::entityManager": "https://www.drupal.org/files/issues/2022-08-11/3303003-use-entity_type-service.patch"
+            }
         }
     }
 }


### PR DESCRIPTION
Field Conditions is making a call to \Drupal::entityManager() which is deprecated and now removed from Drupal 9.x.

The issue on drupal dot org is here: https://www.drupal.org/project/fico/issues/3303003

FiCo is listed as "minimally maintained" so it may also need to be patched for Drupal 10 soon.